### PR TITLE
Fix b2a import for ie

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ module.exports = {
 
   options: {
     autoImport: {
+      alias: {
+        'b2a': 'b2a/lib/index.js'
+      },
       exclude: [],
       webpack: {}
     }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
   options: {
     autoImport: {
       alias: {
+        // otherwise will default to /src/index.js, which is not transpiled
         'b2a': 'b2a/lib/index.js'
       },
       exclude: [],


### PR DESCRIPTION
By default `b2a`'s entry point is `/src/index.js`, which is not transpiled, resulting in syntax errors in IE.

This uses the auto-import config to change that to the transpiled `/lib/index.js`

